### PR TITLE
Add Audiowide font and styled dashboard title

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2709,7 +2709,15 @@ app.layout = html.Div([
 
     # ─── Title bar + Dashboard-toggle button ───────────────────────────────
     html.Div([
-        html.H3(id="dashboard-title", children=tr("dashboard_title"), className="m-0"),
+        html.H3(
+            id="dashboard-title",
+            children=(
+                [title_parts[0], html.Span("Enpresor", className="enpresor-font"), title_parts[1]]
+                if len((title_parts := tr("dashboard_title").split("Enpresor"))) == 2
+                else tr("dashboard_title")
+            ),
+            className="m-0",
+        ),
         dbc.Button(tr("switch_dashboards"),
                    id="new-dashboard-btn",
                    color="light", size="sm", className="ms-2"),

--- a/assets/Audiowide-Regular.ttf
+++ b/assets/Audiowide-Regular.ttf
@@ -1,0 +1,1 @@
+../Audiowide-Regular.ttf

--- a/assets/audiowide.css
+++ b/assets/audiowide.css
@@ -1,0 +1,7 @@
+@font-face {
+    font-family: 'Audiowide';
+    src: url('Audiowide-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+.enpresor-font { font-family: 'Audiowide', sans-serif; }

--- a/callbacks.py
+++ b/callbacks.py
@@ -5,6 +5,12 @@ def register_callbacks(app):
     main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
     globals().update({k:v for k,v in vars(main).items() if k not in globals()})
 
+    def format_enpresor(text: str):
+        parts = text.split("Enpresor")
+        if len(parts) == 2:
+            return [parts[0], html.Span("Enpresor", className="enpresor-font"), parts[1]]
+        return text
+
     # Create a client-side callback to handle theme switching
     app.clientside_callback(
         """
@@ -1119,8 +1125,9 @@ def register_callbacks(app):
     )
     def update_dashboard_title(active_machine_data, current_dashboard, lang, machines_data):
         """Update dashboard title to show active machine"""
-        base_title = tr("dashboard_title", lang)
-        
+        base_title = format_enpresor(tr("dashboard_title", lang))
+        base_list = base_title if isinstance(base_title, list) else [base_title]
+
         if current_dashboard == "main" and active_machine_data and active_machine_data.get("machine_id"):
             machine_id = active_machine_data["machine_id"]
             
@@ -1134,8 +1141,8 @@ def register_callbacks(app):
                             machine_name = f"{tr('machine_label', lang)} {machine_id} (S/N: {serial})"
                         break
             
-            return f"{base_title} - {machine_name}"
-        
+            return base_list + [f" - {machine_name}"]
+
         return base_title
 
     @app.callback(


### PR DESCRIPTION
## Summary
- add Audiowide font asset and CSS
- style dashboard title with Audiowide
- return styled title in callback

## Testing
- `python3 -m py_compile EnpresorOPCDataViewBeforeRestructureLegacy.py callbacks.py i18n.py`
- `pip install -q dash dash-bootstrap-components pandas reportlab plotly numpy opcua python-i18n`
- `python3 EnpresorOPCDataViewBeforeRestructureLegacy.py --no-open-browser --debug` *(stopped after launch)*

------
https://chatgpt.com/codex/tasks/task_e_685f650f6c548327a9e7f98d58e2fc12