### PR TITLE
Change Enpresor title text color

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2712,7 +2712,11 @@ app.layout = html.Div([
         html.H3(
             id="dashboard-title",
             children=(
-                [title_parts[0], html.Span("Enpresor", className="enpresor-font"), title_parts[1]]
+                [
+                    title_parts[0],
+                    html.Span("Enpresor", className="enpresor-font", style={"color": "red"}),
+                    title_parts[1],
+                ]
                 if len((title_parts := tr("dashboard_title").split("Enpresor"))) == 2
                 else tr("dashboard_title")
             ),

--- a/callbacks.py
+++ b/callbacks.py
@@ -8,7 +8,11 @@ def register_callbacks(app):
     def format_enpresor(text: str):
         parts = text.split("Enpresor")
         if len(parts) == 2:
-            return [parts[0], html.Span("Enpresor", className="enpresor-font"), parts[1]]
+            return [
+                parts[0],
+                html.Span("Enpresor", className="enpresor-font", style={"color": "red"}),
+                parts[1],
+            ]
         return text
 
     # Create a client-side callback to handle theme switching


### PR DESCRIPTION
## Summary
- set inline red color for the Enpresor text in the title bar
- apply same red style when formatting translated titles

## Testing
- `python3 -m py_compile EnpresorOPCDataViewBeforeRestructureLegacy.py callbacks.py i18n.py generate_report.py hourly_data_saving.py`

------
https://chatgpt.com/codex/tasks/task_e_685f66887fcc83278e4e636bb16847cd