### PR TITLE
Fix undefined lang variable in Dash layout

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2747,17 +2747,17 @@ app.layout = html.Div([
             ),
             className="m-0",
         ),
-        dbc.Button(tr("switch_dashboards", lang),
+        dbc.Button(tr("switch_dashboards", _initial_lang),
                    id="new-dashboard-btn",
                    color="light", size="sm", className="ms-2"),
-        dbc.Button(tr("generate_report", lang),
+        dbc.Button(tr("generate_report", _initial_lang),
                    id="generate-report-btn",
                    color="light", size="sm", className="ms-2"),
         dcc.Download(id="report-download"),
     ], className="d-flex justify-content-between align-items-center bg-primary text-white p-2 mb-2"),
 
     # ─── Connection controls (always visible) ──────────────────────────────
-    connection_controls(lang),
+    connection_controls(_initial_lang),
 
     dbc.Modal([
         dbc.ModalHeader(html.Span(tr("upload_image_title"), id="upload-modal-header")),


### PR DESCRIPTION
## Summary
- replace undefined `lang` variable in layout with `_initial_lang`

## Testing
- `python EnpresorOPCDataViewBeforeRestructureLegacy.py --no-open-browser --debug` *(fails: cryptography is not installed, use of crypto disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685f7b1d6a388327864fa653b730d780