### PR TITLE
Add feeder state columns to metrics

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4756,6 +4756,8 @@ def register_callbacks(app):
                         "accepts": convert_capacity_to_lbs(accepts, weight_pref),
                         "rejects": convert_capacity_to_lbs(rejects, weight_pref),
                         "objects_per_min": 0,
+                        "running": 1,
+                        "stopped": 0,
                     }
     
                     counters = m.get("demo_counters", [0] * 12)
@@ -4785,11 +4787,23 @@ def register_callbacks(app):
             if opm is None:
                 opm = 0
     
+            # Determine feeder running state
+            feeder_running = False
+            for i in range(1, 5):
+                run_tag = f"Status.Feeders.{i}IsRunning"
+                if run_tag in tags:
+                    val = tags[run_tag]["data"].latest_value
+                    if bool(val):
+                        feeder_running = True
+                        break
+
             metrics = {
                 "capacity": capacity_lbs,
                 "accepts": accepts_lbs,
                 "rejects": rejects_lbs,
                 "objects_per_min": opm,
+                "running": 1 if feeder_running else 0,
+                "stopped": 0 if feeder_running else 1,
             }
     
             for i in range(1, 13):

--- a/hourly_data_saving.py
+++ b/hourly_data_saving.py
@@ -40,6 +40,8 @@ def get_historical_data(timeframe: str = "24h", export_dir: str = EXPORT_DIR,
         "capacity": {"times": [], "values": []},
         "accepts": {"times": [], "values": []},
         "rejects": {"times": [], "values": []},
+        "running": {"times": [], "values": []},
+        "stopped": {"times": [], "values": []},
         **{i: {"times": [], "values": []} for i in range(1, 13)},
     }
 
@@ -51,6 +53,13 @@ def get_historical_data(timeframe: str = "24h", export_dir: str = EXPORT_DIR,
 
     # Filter accepts and rejects history
     for key in ("accepts", "rejects"):
+        for t, v in zip(history[key]["times"], history[key]["values"]):
+            if t >= cutoff:
+                filtered[key]["times"].append(t)
+                filtered[key]["values"].append(v)
+
+    # Filter running/stopped history
+    for key in ("running", "stopped"):
         for t, v in zip(history[key]["times"], history[key]["values"]):
             if t >= cutoff:
                 filtered[key]["times"].append(t)
@@ -176,6 +185,8 @@ def load_recent_metrics(export_dir: str = EXPORT_DIR, machine_id: Optional[str] 
         "capacity": {"times": [], "values": []},
         "accepts": {"times": [], "values": []},
         "rejects": {"times": [], "values": []},
+        "running": {"times": [], "values": []},
+        "stopped": {"times": [], "values": []},
         **{i: {"times": [], "values": []} for i in range(1, 13)},
     }
 
@@ -213,6 +224,15 @@ def load_recent_metrics(export_dir: str = EXPORT_DIR, machine_id: Optional[str] 
                     history["rejects"]["values"].append(val)
                 except ValueError:
                     pass
+
+            for key in ("running", "stopped"):
+                if key in row and row[key]:
+                    try:
+                        val = float(row[key])
+                        history[key]["times"].append(ts)
+                        history[key]["values"].append(val)
+                    except ValueError:
+                        pass
 
             for i in range(1, 13):
                 key = f"counter_{i}"


### PR DESCRIPTION
## Summary
- include running/stopped data in historical metrics
- compute feeder state for each machine when logging metrics

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff2af377483279fa1f67c6035290e