### PR TITLE
Enable plant view callback on initial load

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -1277,7 +1277,7 @@ def register_callbacks(app):
          Input("active-machine-store", "data"),
          Input("app-mode", "data"),
          Input("language-preference-store", "data")],
-        prevent_initial_call=True
+        prevent_initial_call=False
     )
     def render_floor_machine_layout_enhanced_with_selection(machines_data, floors_data, ip_addresses_data, additional_image_data, current_dashboard, active_machine_data, app_mode_data, lang):
         """Enhanced render with machine selection capability"""

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import dash
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+
+
+def test_floor_machine_callback_registered():
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    assert "floor-machine-container.children" in app.callback_map


### PR DESCRIPTION
## Summary
- ensure `render_floor_machine_layout_enhanced_with_selection` executes on initial page load by setting `prevent_initial_call=False`
- add regression test confirming the callback is registered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffe816f408327b7368c71056b5713