### PR TITLE
Fix callback import for packaged app

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -1,9 +1,15 @@
 import importlib
+import sys
 import autoconnect
 
 
 def register_callbacks(app):
-    main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
+    try:
+        main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
+    except ModuleNotFoundError:
+        main = sys.modules.get("__main__")
+        if main is None:
+            raise
     globals().update({k: v for k, v in vars(main).items() if k not in globals()})
     for name in [
         "app_state",


### PR DESCRIPTION
## Summary
- avoid ModuleNotFoundError when importing callbacks in packaged executables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68616d68e0b483278e9dd9f8089595c3