### PR TITLE
Improve Audiowide font handling

### DIFF
--- a/EnpresorOPCViewerInstaller.iss
+++ b/EnpresorOPCViewerInstaller.iss
@@ -9,6 +9,7 @@ SetupIconFile=EnpresorDataIcon.ico
 [Files]
 Source: "dist\EnpresorOPCDataViewBeforeRestructureLegacy\*"; DestDir: "{app}"; Flags: recursesubdirs
 Source: "EnpresorDataIcon.ico"; DestDir: "{app}"
+Source: "Audiowide-Regular.ttf"; DestDir: "{app}"
 
 [Icons]
 Name: "{commondesktop}\Enpresor OPC Viewer"; Filename: "{app}\EnpresorOPCDataViewBeforeRestructureLegacy.exe"; WorkingDir: "{app}"; IconFilename: "{app}\EnpresorDataIcon.ico"

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ For production deployments you can run the Dash application using Gunicorn.
    gunicorn --bind 0.0.0.0:8050 wsgi:application
    ```
 
+## Packaging
+
+When creating a frozen executable (for example with PyInstaller) or building the
+Windows installer using the provided Inno Setup script, make sure the
+`Audiowide-Regular.ttf` font file is included alongside the application. The
+installer script copies this file automatically so the PDF headers render with
+the correct font.
+


### PR DESCRIPTION
## Summary
- detect PyInstaller frozen mode to locate bundled assets
- search for Audiowide font in executable folder and assets subfolder
- log which font path was loaded
- package Audiowide font in Inno Setup script
- document packaging requirements
- test font loading when `_MEIPASS` is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c71c70508327957381944a928d07