### PR TITLE
Update packaging docs for Audiowide font

### DIFF
--- a/EnpresorOPCViewerInstaller.iss
+++ b/EnpresorOPCViewerInstaller.iss
@@ -9,7 +9,7 @@ SetupIconFile=EnpresorDataIcon.ico
 [Files]
 Source: "dist\EnpresorOPCDataViewBeforeRestructureLegacy\*"; DestDir: "{app}"; Flags: recursesubdirs
 Source: "EnpresorDataIcon.ico"; DestDir: "{app}"
-Source: "Audiowide-Regular.ttf"; DestDir: "{app}"
+Source: "Audiowide-Regular.ttf"; DestDir: "{app}\assets"
 
 [Icons]
 Name: "{commondesktop}\Enpresor OPC Viewer"; Filename: "{app}\EnpresorOPCDataViewBeforeRestructureLegacy.exe"; WorkingDir: "{app}"; IconFilename: "{app}\EnpresorDataIcon.ico"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ For production deployments you can run the Dash application using Gunicorn.
 
 When creating a frozen executable (for example with PyInstaller) or building the
 Windows installer using the provided Inno Setup script, make sure the
-`Audiowide-Regular.ttf` font file is included alongside the application. The
-installer script copies this file automatically so the PDF headers render with
-the correct font.
+`Audiowide-Regular.ttf` font file is bundled with the application. `draw_header`
+will look for the font either in the application directory or an `assets`
+subfolder. The installer script copies the file into `assets` automatically so
+the PDF headers render with the correct font.
 


### PR DESCRIPTION
## Summary
- clarify packaging instructions about Audiowide font
- copy Audiowide font into installer assets folder

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cf5832ec8327b001b0fd5c3a7dc2