### PR TITLE
Handle internal assets when frozen

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -50,6 +50,8 @@ def draw_header(c, width, height, page_number=None):
             os.path.join(base_dir, "assets"),
             exec_dir,
             os.path.join(exec_dir, "assets"),
+            os.path.join(exec_dir, "_internal"),
+            os.path.join(exec_dir, "_internal", "assets"),
         ]
     else:
         base_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -131,3 +131,36 @@ def test_draw_header_uses_executable_dir_font(tmp_path, monkeypatch):
 
     assert captured["path"] == str(target)
     assert captured["registered"] == "Audiowide"
+
+
+def test_draw_header_uses_internal_assets_font(tmp_path, monkeypatch):
+    """Font is loaded from <exec_dir>/_internal/assets when frozen."""
+    exec_dir = tmp_path / "exec"
+    internal_assets = exec_dir / "_internal" / "assets"
+    internal_assets.mkdir(parents=True)
+
+    font_src = Path(__file__).resolve().parents[1] / "Audiowide-Regular.ttf"
+    target = internal_assets / "Audiowide-Regular.ttf"
+    target.write_bytes(font_src.read_bytes())
+
+    monkeypatch.setattr(generate_report.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(generate_report.sys, "_MEIPASS", str(tmp_path / "notused"), raising=False)
+    monkeypatch.setattr(generate_report.sys, "executable", str(exec_dir / "app.exe"), raising=False)
+
+    captured = {}
+
+    def fake_TTFont(name, path):
+        captured["path"] = path
+        return types.SimpleNamespace(name=name)
+
+    def fake_register(font):
+        captured["registered"] = font.name
+
+    monkeypatch.setattr(generate_report, "TTFont", fake_TTFont)
+    monkeypatch.setattr(generate_report.pdfmetrics, "registerFont", fake_register)
+
+    canvas = DummyCanvas()
+    generate_report.draw_header(canvas, 100, 100)
+
+    assert captured["path"] == str(target)
+    assert captured["registered"] == "Audiowide"


### PR DESCRIPTION
## Summary
- search for fonts in `_internal` directories when frozen
- test loading fonts from `_internal/assets` folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861dae6c4f083278b2ddbbe977785f5