### PR TITLE
Fix duplicate global state in register_callbacks

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4,13 +4,14 @@ import autoconnect
 
 
 def register_callbacks(app):
-    try:
-        main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
-    except ModuleNotFoundError:
-        main = sys.modules.get("__main__")
-        if main is None:
-            raise
-    globals().update({k: v for k, v in vars(main).items() if k not in globals()})
+    main = sys.modules.get("EnpresorOPCDataViewBeforeRestructureLegacy")
+    if main is None:
+        candidate = sys.modules.get("__main__")
+        if candidate and getattr(candidate, "__file__", "").endswith("EnpresorOPCDataViewBeforeRestructureLegacy.py"):
+            main = candidate
+        else:
+            main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
+    globals().update({k: v for k, v in vars(main).items() if not k.startswith("__")})
     for name in [
         "app_state",
         "machine_connections",

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import callbacks
 import autoconnect
+import pytest
 
 
 def test_floor_machine_callback_registered():
@@ -31,3 +32,77 @@ def test_register_callbacks_starts_autoconnect(monkeypatch):
     callbacks.register_callbacks(app)
 
     assert any(t.started for t in started)
+
+
+def test_register_callbacks_uses_existing_module(monkeypatch):
+    """Existing module instance should be reused without reimporting."""
+    from types import ModuleType
+
+    existing = ModuleType("EnpresorOPCDataViewBeforeRestructureLegacy")
+    existing.sentinel = 123
+
+    monkeypatch.setitem(sys.modules,
+                        "EnpresorOPCDataViewBeforeRestructureLegacy", existing)
+
+    called = False
+    orig_import = callbacks.importlib.import_module
+
+    def fake_import(name, package=None):
+        nonlocal called
+        if name == "EnpresorOPCDataViewBeforeRestructureLegacy":
+            called = True
+            return existing
+        return orig_import(name, package)
+
+    monkeypatch.setattr(callbacks.importlib, "import_module", fake_import)
+    def stop():
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", stop)
+
+    app = dash.Dash(__name__)
+    with pytest.raises(RuntimeError):
+        callbacks.register_callbacks(app)
+
+    assert not called
+    assert callbacks.sentinel == 123
+
+
+def test_register_callbacks_uses_main_module(monkeypatch):
+    """When executed as a script, __main__ should supply globals."""
+    from types import ModuleType
+
+    main_mod = ModuleType("__main__")
+    main_mod.__file__ = "EnpresorOPCDataViewBeforeRestructureLegacy.py"
+    main_mod.sentinel = 1
+
+    monkeypatch.setitem(sys.modules, "__main__", main_mod)
+    monkeypatch.delitem(sys.modules, "EnpresorOPCDataViewBeforeRestructureLegacy", raising=False)
+
+    called = False
+    orig_import = callbacks.importlib.import_module
+
+    def fake_import(name, package=None):
+        nonlocal called
+        if name == "EnpresorOPCDataViewBeforeRestructureLegacy":
+            called = True
+            return main_mod
+        return orig_import(name, package)
+
+    monkeypatch.setattr(callbacks.importlib, "import_module", fake_import)
+    def stop():
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", stop)
+
+    app = dash.Dash(__name__)
+    with pytest.raises(RuntimeError):
+        callbacks.register_callbacks(app)
+
+    # modify state and call again
+    main_mod.sentinel = 2
+    with pytest.raises(RuntimeError):
+        callbacks.register_callbacks(app)
+
+    assert not called
+    assert callbacks.sentinel == 2


### PR DESCRIPTION
## Summary
- stop re-importing `EnpresorOPCDataViewBeforeRestructureLegacy`
- populate callback globals from the single loaded instance
- test re-use of an existing module and use of `__main__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ab13e4f483279fd880bbbeb3a5e8