### PR TITLE
Ensure main module reuse

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -11,7 +11,9 @@ def register_callbacks(app):
             main = candidate
         else:
             main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
-    globals().update({k: v for k, v in vars(main).items() if not k.startswith("__")})
+
+    sys.modules.setdefault("EnpresorOPCDataViewBeforeRestructureLegacy", main)
+    globals().update({k: v for k, v in vars(main).items() if not k.startswith("_")})
     for name in [
         "app_state",
         "machine_connections",


### PR DESCRIPTION
## Summary
- cache the chosen main module inside `register_callbacks`
- test `register_callbacks` caching behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862aff1b5f08327b5abb7fd76cde4d1