### PR TITLE
Enable debug mode for logging

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -4803,6 +4803,9 @@ if __name__ == "__main__":
 
         logger.info("Starting dashboard application...")
 
+        if args.debug:
+            logger.setLevel(logging.DEBUG)
+
         logger.info("Initializing auto-connect logic...")
         autoconnect.initialize_autoconnect()
 
@@ -4847,7 +4850,7 @@ if __name__ == "__main__":
             threading.Thread(target=open_browser).start()
 
         # Start the Dash app
-        app.run(debug=False, use_reloader=False, host='0.0.0.0', port=8050)
+        app.run(debug=args.debug, use_reloader=False, host='0.0.0.0', port=8050)
         
     except KeyboardInterrupt:
         # Disconnect on exit

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Run the dashboard from the repository root:
 ```bash
 python3 EnpresorOPCDataViewBeforeRestructureLegacy.py
 ```
-The script prints the local and network URLs for accessing the interface. Optionally use `--open-browser` to automatically open your web browser and `--debug` for verbose output.
+The script prints the local and network URLs for accessing the interface. Optionally use `--open-browser` to automatically open your web browser and `--debug` for verbose output. When debug mode is enabled the server runs with Dash debugging turned on and the application's logger level is set to `DEBUG` so additional messages are shown.
 
 As the code is refactored into modules, the entry point and command-line options will remain consistent so that users experience no change in behavior.
 


### PR DESCRIPTION
## Summary
- wire `--debug` flag through to `app.run`
- raise log level to DEBUG when debug mode is active
- document debug behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bf7add888327825baf038ccba122