### PR TITLE
Route callback debugging through logger

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -2,6 +2,12 @@ import importlib
 import sys
 import autoconnect
 
+try:
+    from EnpresorOPCDataViewBeforeRestructureLegacy import logger
+except Exception:  # pragma: no cover - fallback if main script isn't loaded yet
+    import logging
+    logger = logging.getLogger(__name__)
+
 # Flag to prevent re-entrancy when the legacy module imports this module and
 # executes ``register_callbacks`` during import.
 _REGISTERING = False
@@ -185,12 +191,12 @@ def _register_callbacks_impl(app):
     def manage_dashboard(n_clicks, current):
         # On first load n_clicks is None → show the new dashboard
         if n_clicks is None:
-            print("DEBUG: manage_dashboard -> new (initial load)", flush=True)
+            logger.debug("manage_dashboard -> new (initial load)")
             return "new"
 
         # On every actual click, flip between “main” and “new”
         new_value = "new" if current == "main" else "main"
-        print(f"DEBUG: manage_dashboard toggled to {new_value}", flush=True)
+        logger.debug("manage_dashboard toggled to %s", new_value)
         return new_value
 
     @app.callback(
@@ -895,7 +901,11 @@ def _register_callbacks_impl(app):
         if machine_id is None:
             return dash.no_update, dash.no_update, dash.no_update
 
-        print(f"DEBUG: handle_machine_selection triggered by {triggered_prop}, machine_id={machine_id}", flush=True)
+        logger.debug(
+            "handle_machine_selection triggered by %s, machine_id=%s",
+            triggered_prop,
+            machine_id,
+        )
 
         # Set this machine as the active machine
         active_machine_id = machine_id
@@ -903,7 +913,7 @@ def _register_callbacks_impl(app):
         
         # Check if the machine is connected
         is_conn = machine_id in machine_connections and machine_connections[machine_id].get('connected', False)
-        print(f"DEBUG: machine {machine_id} connected={is_conn}", flush=True)
+        logger.debug("machine %s connected=%s", machine_id, is_conn)
         if is_conn:
             # Machine is connected - set up app_state to point to this machine's data
             connection_info = machine_connections[machine_id]
@@ -937,7 +947,7 @@ def _register_callbacks_impl(app):
         # Ensure the update thread is running after switching machines
         resume_update_thread()
         alive = app_state.update_thread.is_alive() if app_state.update_thread else False
-        print(f"DEBUG: update thread alive={alive}", flush=True)
+        logger.debug("update thread alive=%s", alive)
 
         # Return to main dashboard with selected machine
         return "main", {"machine_id": machine_id}, app_state_data


### PR DESCRIPTION
## Summary
- import `logger` from main script with fallback
- use `logger.debug` instead of `print` debugging in callbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bf78009083279d77847d6cc93866