### PR TITLE
Fix machine card selection logic

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -126,3 +126,11 @@ def test_register_callbacks_no_recursion(monkeypatch):
 
     assert init_calls == [1]
 
+
+def test_extract_clicked_machine_id():
+    trig = '{"index": 2, "type": "machine-card-click"}.n_clicks'
+    assert callbacks._extract_clicked_machine_id(trig, [None, 1], [{"index": 1}, {"index": 2}]) == 2
+
+    trig = 'other'
+    assert callbacks._extract_clicked_machine_id(trig, [None, 1, None], [{"index": 1}, {"index": 2}, {"index": 3}]) == 2
+


### PR DESCRIPTION
## Summary
- add helper to reliably parse clicked machine id
- use triggered_id to set active machine
- test helper function

## Testing
- `pip install -q -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d7c2f50c8327a318b011bccaa329