### PR TITLE
Add server time check after OPC UA connection

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -3107,6 +3107,17 @@ async def connect_and_discover_machine_tags(ip_address, machine_id, server_name=
         
         # Connect to server
         client.connect()
+
+        # Verify connection by requesting server time
+        try:
+            server_time = client.get_server_time()
+            logger.info(
+                f"Server time for machine {machine_id}: {server_time}"
+            )
+        except Exception as e:
+            logger.error(f"Connection failed: {e}")
+            return False
+
         logger.info(f"Connected successfully to machine {machine_id} at {ip_address}")
         
         # Discover tags using the exact same logic as main connection


### PR DESCRIPTION
## Summary
- connect_and_monitor_machine logs OPC UA server time
- abort connection if server time fails to fetch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d0ee8b9883278e89ef39ed2ed386