### PR TITLE
Add debug logs for update thread

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -900,6 +900,12 @@ def opc_update_thread():
     max_failures = 5
     
     while not app_state.thread_stop_flag:
+        logger.debug(
+            "opc_update_thread loop: mode=%s, active_machine=%s, stop_flag=%s",
+            current_app_mode,
+            active_machine_id,
+            app_state.thread_stop_flag,
+        )
         try:
             # Only update if we have an active, connected machine
             if not app_state.connected or not app_state.client:

--- a/callbacks.py
+++ b/callbacks.py
@@ -931,6 +931,12 @@ def _register_callbacks_impl(app):
             app_state.update_thread.daemon = True
             app_state.update_thread.start()
             logger.info(f"Started new OPC update thread for machine {machine_id}")
+            logger.debug(
+                "Thread status after selection: mode=%s, active_machine=%s, alive=%s",
+                current_app_mode,
+                active_machine_id,
+                app_state.update_thread.is_alive(),
+            )
             
             logger.info(f"Switched to connected machine {machine_id} - {len(app_state.tags)} tags available")
             app_state_data["connected"] = True
@@ -1821,9 +1827,17 @@ def _register_callbacks_impl(app):
         if which != "main":
             #print("DEBUG: Preventing update for section-1-1")
             raise PreventUpdate
-        
-    
+
+
         global previous_counter_values
+
+        logger.debug(
+            "update_section_1_1: mode=%s, active_machine=%s, thread_alive=%s, stop_flag=%s",
+            current_app_mode,
+            active_machine_id,
+            app_state.update_thread.is_alive() if app_state.update_thread else False,
+            app_state.thread_stop_flag,
+        )
         
     
         # Tag definitions - Easy to update when actual tag names are available


### PR DESCRIPTION
## Summary
- log update thread state in section callback
- log state when starting thread after machine selection
- log loop data from the background update thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643a9856648327bd96cd799ad82eba