### PR TITLE
Add debug logging for feed rate changes

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4352,6 +4352,7 @@ def _register_callbacks_impl(app):
                     new_val = app_state.tags[opc_tag]["data"].latest_value
                     prev_val = machine_prev.get(opc_tag)
                     if prev_val is not None and new_val is not None and new_val != prev_val:
+                        logger.debug("Rate %s changed from %s to %s", opc_tag, prev_val, new_val)
                         add_control_log_entry(friendly_name, prev_val, new_val, machine_id=machine_id)
                     machine_prev[opc_tag] = new_val
     


### PR DESCRIPTION
## Summary
- track previous values of monitored feed rate tags
- emit debug logs when values change in live or lab mode

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686450b8282c8327a3794ddcdb4f62d3