### PR TITLE
Fix log truncation in legacy view

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -595,7 +595,7 @@ def add_control_log_entry(tag_name, old_value, new_value, *, demo=False,
     # Add to log and keep only most recent 100 entries
     global machine_control_log
     machine_control_log.insert(0, entry)  # Insert at beginning (newest first)
-    machine_control_log = machine_control_log[:100]  # Keep only most recent 100
+    del machine_control_log[100:]  # Keep only most recent 100 entries
 
     entry_for_file = entry.copy()
     entry_for_file.pop("machine_id", None)
@@ -627,7 +627,7 @@ def add_activation_log_entry(sens_num, enabled, *, demo=False, machine_id=None):
 
     global machine_control_log
     machine_control_log.insert(0, entry)
-    machine_control_log = machine_control_log[:100]
+    del machine_control_log[100:]  # Keep only most recent 100 entries
 
     entry_for_file = entry.copy()
     entry_for_file.pop("machine_id", None)

--- a/EnpresorOPCDataViewBeforeRestructureORIGINAL.py
+++ b/EnpresorOPCDataViewBeforeRestructureORIGINAL.py
@@ -587,7 +587,7 @@ def add_control_log_entry(tag_name, old_value, new_value, *, demo=False,
     # Add to log and keep only most recent 100 entries
     global machine_control_log
     machine_control_log.insert(0, entry)  # Insert at beginning (newest first)
-    machine_control_log = machine_control_log[:100]  # Keep only most recent 100
+    del machine_control_log[100:]  # Keep only most recent 100 entries
 
     entry_for_file = entry.copy()
     entry_for_file.pop("machine_id", None)
@@ -619,7 +619,7 @@ def add_activation_log_entry(sens_num, enabled, *, demo=False, machine_id=None):
 
     global machine_control_log
     machine_control_log.insert(0, entry)
-    machine_control_log = machine_control_log[:100]
+    del machine_control_log[100:]  # Keep only most recent 100 entries
 
     entry_for_file = entry.copy()
     entry_for_file.pop("machine_id", None)


### PR DESCRIPTION
## Summary
- update control/activation log truncation in legacy and original dashboards
- keep in-memory logs sliced in place rather than reassigned

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a03724c88327a42b6bcceff0ac48