### PR TITLE
Enhance control log icons

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -574,16 +574,19 @@ def add_control_log_entry(tag_name, old_value, new_value, *, demo=False,
     
     # Determine if value increased or decreased using arrows for compact display
     if new_value > old_value:
-        action = "\u2191"  # Up arrow for increase
+        icon = "\u2B06"  # Up arrow
     elif new_value < old_value:
-        action = "\u2193"  # Down arrow for decrease
+        icon = "\u2B07"  # Down arrow
     else:
-        action = "\u2192"  # Right arrow for unchanged values
+        icon = "\u2192"  # Right arrow for unchanged values
+
+    action = icon
     
     # Create log entry
     entry = {
         "tag": tag_name,
         "action": action,
+        "icon": icon,
         "old_value": old_value,
         "new_value": new_value,
         "display_timestamp": timestamp,

--- a/callbacks.py
+++ b/callbacks.py
@@ -4582,12 +4582,24 @@ def _register_callbacks_impl(app):
     
             tag_translated = _translate_tag(entry.get('tag', ''))
     
-            if entry.get("icon"):
+            icon_val = entry.get("icon")
+            if icon_val in ("✅", "❌"):
                 color_class = "text-success" if entry.get("action") == "Enabled" else "text-danger"
-                icon = html.Span(entry.get("icon"), className=color_class)
+                icon = html.Span(icon_val, className=color_class)
                 log_entries.append(
                     html.Div(
                         [f"{idx}. {tag_translated} {entry.get('action')} ", icon, f" {timestamp}"],
+                        className="mb-1 small",
+                        style={"whiteSpace": "nowrap"},
+                    )
+                )
+            elif icon_val in ("⬆", "⬇"):
+                color_class = "text-success" if icon_val == "⬆" else "text-danger"
+                icon = html.Span(icon_val, className=color_class)
+                value_change = f"{entry.get('old_value', '')} -> {entry.get('new_value', '')}"
+                log_entries.append(
+                    html.Div(
+                        [f"{idx}. {tag_translated} ", icon, f" {value_change} {timestamp}"],
                         className="mb-1 small",
                         style={"whiteSpace": "nowrap"},
                     )

--- a/tests/test_update_section_7_2.py
+++ b/tests/test_update_section_7_2.py
@@ -30,7 +30,11 @@ def test_update_section_7_2_logs_changes(monkeypatch):
 
     func.__wrapped__(0, "main", {}, "en", {"connected": True}, {"mode": "live"}, {"machine_id": machine_id})
     assert len(legacy.machine_control_log) == 1
+    assert legacy.machine_control_log[0]["icon"] == "⬆"
 
     callbacks.app_state.tags[tag_name]["data"].latest_value = 30
     func.__wrapped__(1, "main", {}, "en", {"connected": True}, {"mode": "live"}, {"machine_id": machine_id})
     assert len(legacy.machine_control_log) == 2
+    # Most recent entry is first in the log
+    assert legacy.machine_control_log[0]["icon"] == "⬆"
+    assert legacy.machine_control_log[1]["icon"] == "⬆"


### PR DESCRIPTION
## Summary
- add an `icon` field in `add_control_log_entry` for arrow indicators
- color rate change arrows in `update_section_7_2`
- test that log entries include the new icon field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686938b3a3c48327aeafeafe4eb3fe38