### PR TITLE
Add preset name logging

### DIFF
--- a/tests/test_update_section_7_2.py
+++ b/tests/test_update_section_7_2.py
@@ -38,3 +38,22 @@ def test_update_section_7_2_logs_changes(monkeypatch):
     # Most recent entry is first in the log
     assert legacy.machine_control_log[0]["icon"] == "⬆"
     assert legacy.machine_control_log[1]["icon"] == "⬆"
+
+
+def test_update_section_7_2_logs_preset_change(monkeypatch):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = app.callback_map["section-7-2.children"]["callback"]
+
+    machine_id = 2
+    callbacks.app_state.tags = {callbacks.PRESET_NAME_TAG: {"data": callbacks.TagData("preset")}}
+    callbacks.app_state.connected = True
+    legacy.machine_control_log.clear()
+
+    callbacks.prev_preset_names[machine_id] = "Old"
+    callbacks.app_state.tags[callbacks.PRESET_NAME_TAG]["data"].latest_value = "New"
+
+    func.__wrapped__(0, "main", {}, "en", {"connected": True}, {"mode": "live"}, {"machine_id": machine_id})
+    assert len(legacy.machine_control_log) == 1
+    assert legacy.machine_control_log[0]["icon"] == "🔄"


### PR DESCRIPTION
## Summary
- track previous preset names per machine
- log preset name changes with a new swap icon
- watch for preset name updates when machines connect and during monitoring
- render preset change logs in machine control log
- test preset change logging

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686941810928832788801e6f9ba41abf