### PR TITLE
Add processed weight to machine counts

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -771,6 +771,11 @@ def draw_machine_sections(c, csv_parent_dir, machine, x0, y_start, total_w, avai
     
     machine_accepts = df[ac_col].sum() if ac_col else 0
     machine_rejects = df[rj_col].sum() if rj_col else 0
+
+    machine_processed_lbs = 0
+    if 'capacity' in df.columns:
+        cap_stats = calculate_total_capacity_from_csv_rates(df['capacity'])
+        machine_processed_lbs = cap_stats['total_capacity_lbs']
     
     # Draw SMALLER blue counts section
     c.setFillColor(colors.HexColor('#1f77b4'))
@@ -802,21 +807,26 @@ def draw_machine_sections(c, csv_parent_dir, machine, x0, y_start, total_w, avai
         vw = c.stringWidth(val, 'Helvetica-Bold', 14)
         c.drawString(center_x - vw/2, y_counts + counts_height * 0.7 - 14, val)
     
-    # BOTTOM ROW: Accepts and Rejects
-    labs_bottom = ['Accepts:', 'Rejects:']  # Shortened labels
-    vals_bottom = [f"{int(machine_accepts):,} lbs", f"{int(machine_rejects):,} lbs"]
-    
+    # BOTTOM ROW: Processed, Accepts and Rejects
+    third_counts = total_w / 3
+    labs_bottom = ['Processed:', 'Accepts:', 'Rejects:']
+    vals_bottom = [
+        f"{int(machine_processed_lbs):,} lbs",
+        f"{int(machine_accepts):,} lbs",
+        f"{int(machine_rejects):,} lbs",
+    ]
+
     # Center the labels over their data
-    c.setFont('Helvetica-Bold', 8)  # Keep label font size the same
+    c.setFont('Helvetica-Bold', 8)
     for i, lab in enumerate(labs_bottom):
-        center_x = x0 + half_counts * i + half_counts/2
+        center_x = x0 + third_counts * i + third_counts/2
         lw = c.stringWidth(lab, 'Helvetica-Bold', 8)
         c.drawString(center_x - lw/2, y_counts + counts_height * 0.3, lab)
-    
+
     # Increase data text size and center over labels
-    c.setFont('Helvetica-Bold', 14)  # Increased from 10 to 14
+    c.setFont('Helvetica-Bold', 14)
     for i, val in enumerate(vals_bottom):
-        center_x = x0 + half_counts * i + half_counts/2
+        center_x = x0 + third_counts * i + third_counts/2
         vw = c.stringWidth(val, 'Helvetica-Bold', 14)
         c.drawString(center_x - vw/2, y_counts + counts_height * 0.3 - 14, val)
     

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -115,6 +115,24 @@ def test_draw_machine_sections_runtime_line(tmp_path, monkeypatch):
     assert any("Run Time:" in s for s in canvas.strings)
 
 
+def test_draw_machine_sections_processed_weight(tmp_path, monkeypatch):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir()
+    csv_file = machine_dir / "last_24h_metrics.csv"
+    csv_file.write_text(
+        "timestamp,capacity,accepts,rejects,running,stopped\n"
+        "2020-01-01 00:00:00,60,30,30,65,5\n"
+        "2020-01-01 00:01:00,60,30,30,65,5\n"
+    )
+
+    monkeypatch.setattr(generate_report.renderPDF, "draw", lambda *a, **k: None)
+    canvas = DummyCanvas()
+    generate_report.draw_machine_sections(canvas, str(tmp_path), "1", 0, 200, 100, 200)
+
+    assert "Processed:" in canvas.strings
+    assert "2 lbs" in canvas.strings
+
+
 def test_draw_header_uses_meipass_font(tmp_path, monkeypatch):
     font_src = Path(__file__).resolve().parents[1] / "Audiowide-Regular.ttf"
     target = tmp_path / "Audiowide-Regular.ttf"


### PR DESCRIPTION
## Summary
- show processed weight for each machine in the PDF report
- test new machine-processed weight calculation and display

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686983edc34883278f253993b1ce7681