### PR TITLE
Add notification labels

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -119,6 +119,7 @@ TRANSLATIONS = {
         'password_label': 'Password:',
         'from_address_label': 'From Address:',
         'save_email_settings': 'Save Email Settings',
+        'notification_label': 'Notification',
         'about_this_dashboard_title': 'About This Dashboard',
     },
     'es': {
@@ -241,6 +242,7 @@ TRANSLATIONS = {
         'password_label': 'Contraseña:',
         'from_address_label': 'Dirección del remitente:',
         'save_email_settings': 'Guardar configuración de email',
+        'notification_label': 'Notificación',
         'about_this_dashboard_title': 'Acerca de este tablero',
     },
     'ja': {
@@ -363,6 +365,7 @@ TRANSLATIONS = {
         'password_label': 'パスワード:',
         'from_address_label': '送信元アドレス:',
         'save_email_settings': 'メール設定を保存',
+        'notification_label': '通知',
         'about_this_dashboard_title': 'このダッシュボードについて',
     },
 }


### PR DESCRIPTION
## Summary
- extend i18n translations with `notification_label` in English, Spanish, and Japanese locales

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869da8b59cc83278e9f02628d45a72e