### PR TITLE
Fix threshold labels translation and color

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -1158,16 +1158,35 @@ def create_threshold_settings_form(lang=None):
     if lang is None:
         lang = load_language_preference()
     form_rows = []
-    
+
+    counter_colors = {
+        1: "green",
+        2: "lightgreen",
+        3: "orange",
+        4: "blue",
+        5: "#f9d70b",
+        6: "magenta",
+        7: "cyan",
+        8: "red",
+        9: "purple",
+        10: "brown",
+        11: "gray",
+        12: "lightblue",
+    }
+
     # Create row for each counter
     for i in range(1, 13):
         settings = threshold_settings[i]
-        
+
         form_rows.append(
             dbc.Row([
                 # Counter label
                 dbc.Col(
-                    html.Div(f"{tr('sensitivity_label', lang)} {i}:", className="fw-bold"),
+                    html.Div(
+                        f"{tr('sensitivity_label', lang)} {i}:",
+                        className="fw-bold",
+                        style={"color": counter_colors.get(i, "black")},
+                    ),
                     width=2,
                 ),
                                                 
@@ -1229,7 +1248,7 @@ def create_threshold_settings_form(lang=None):
     form_rows.append(
         dbc.Row([
             # Label
-            dbc.Col(html.Div("Email Notifications:", className="fw-bold"), width=2),
+            dbc.Col(html.Div(f"{tr('notification_label', lang)}:", className="fw-bold"), width=2),
             
             # Email Input
             dbc.Col(

--- a/callbacks.py
+++ b/callbacks.py
@@ -5034,6 +5034,25 @@ def _register_callbacks_impl(app):
         return [no_update]  # Return as a list with one element
 
     @app.callback(
+        Output("threshold-form-container", "children"),
+        [Input({"type": "open-threshold", "index": ALL}, "n_clicks"),
+         Input("language-preference-store", "data")],
+        prevent_initial_call=True,
+    )
+    def refresh_threshold_form(open_clicks, lang):
+        ctx = callback_context
+        if not ctx.triggered:
+            raise PreventUpdate
+
+        trigger = ctx.triggered[0]["prop_id"]
+        if '"type":"open-threshold"' in trigger:
+            if any(click is not None for click in open_clicks):
+                return create_threshold_settings_form(lang)
+        if trigger == "language-preference-store.data":
+            return create_threshold_settings_form(lang)
+        raise PreventUpdate
+
+    @app.callback(
         Output("metric-logging-store", "data"),
         [Input("metric-logging-interval", "n_intervals")],
     

--- a/tests/test_threshold_display_translation.py
+++ b/tests/test_threshold_display_translation.py
@@ -24,6 +24,7 @@ def test_threshold_form_translations(monkeypatch):
     rows_es = mod.create_threshold_settings_form("es")
     assert _get_label_text(rows_en[0]) == "Sensitivity 1:"
     assert "Sensibilidad" in _get_label_text(rows_es[0])
+    assert "Notificación" in _get_label_text(rows_es[-1])
 
 
 def test_display_form_translations(monkeypatch):


### PR DESCRIPTION
## Summary
- translate notification label in threshold settings
- color-code each threshold label
- update threshold form when modal opens or language changes
- test Spanish translation for notification label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869dde70a64832790672780f608525e