### PR TITLE
Add psutil and pillow dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ plotly
 numpy
 opcua
 python-i18n
+
+psutil>=5.9.0
+pillow>=9.0.0


### PR DESCRIPTION
## Summary
- add `psutil` and `pillow` to runtime dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7e7c42bc83279fa356c589c4a956