### PR TITLE
Integrate memory leak management helpers

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -894,6 +894,27 @@ class AppState:
         
 app_state = AppState()
 
+# ---------------------------------------------------------------------------
+# Memory management helpers
+# ---------------------------------------------------------------------------
+from memory_leak_fixes import (
+    MemoryMonitor,
+    CounterHistoryManager,
+    ImageManager,
+    DataFrameProcessor,
+    AppStateManager,
+)
+import atexit
+
+# Instantiate helpers so callbacks can access them
+memory_monitor = MemoryMonitor()
+counter_manager = CounterHistoryManager()
+image_manager = ImageManager()
+data_frame_processor = DataFrameProcessor()
+app_state_manager = AppStateManager(app_state)
+app_state_manager.start_cleanup_thread()
+atexit.register(app_state_manager.stop_cleanup_thread)
+
 # TagData class to store tag history
 from threading import Lock
 

--- a/memory_leak_fixes.py
+++ b/memory_leak_fixes.py
@@ -1,0 +1,92 @@
+import threading
+import time
+import gc
+from typing import Any
+
+class MemoryMonitor:
+    """Simple periodic garbage collector trigger."""
+    def __init__(self, interval: float = 30.0):
+        self.interval = interval
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._running = False
+
+    def start(self) -> None:
+        if not self._running:
+            self._running = True
+            self._thread.start()
+
+    def _run(self) -> None:
+        while self._running:
+            gc.collect()
+            time.sleep(self.interval)
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread.is_alive():
+            self._thread.join(timeout=1)
+
+class CounterHistoryManager:
+    """Track and reset counter history."""
+    def __init__(self) -> None:
+        self.history = []
+        self.lock = threading.Lock()
+
+    def add(self, value: Any) -> None:
+        with self.lock:
+            self.history.append(value)
+
+    def clear(self) -> None:
+        with self.lock:
+            self.history.clear()
+
+class ImageManager:
+    """Manage cached images to avoid memory leaks."""
+    def __init__(self) -> None:
+        self.cache = {}
+        self.lock = threading.Lock()
+
+    def cache_image(self, key: str, data: Any) -> None:
+        with self.lock:
+            self.cache[key] = data
+
+    def purge(self) -> None:
+        with self.lock:
+            self.cache.clear()
+
+class DataFrameProcessor:
+    """Utility for pruning large DataFrames."""
+    def prune(self, df, max_rows: int = 1000):
+        if getattr(df, "shape", (0,))[0] > max_rows:
+            return df.tail(max_rows)
+        return df
+
+class AppStateManager:
+    """Periodically clean up data stored in ``AppState``."""
+    def __init__(self, app_state, interval: float = 60.0):
+        self.app_state = app_state
+        self.interval = interval
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+
+    def start_cleanup_thread(self) -> None:
+        self._thread.start()
+
+    def _loop(self) -> None:
+        while not self._stop_event.is_set():
+            time.sleep(self.interval)
+            self.cleanup()
+
+    def cleanup(self) -> None:
+        tags = getattr(self.app_state, "tags", {})
+        for tag in tags.values():
+            # prune history if TagData-like
+            max_points = getattr(tag, "max_points", None)
+            if max_points is not None and hasattr(tag, "timestamps") and hasattr(tag, "values"):
+                if len(tag.timestamps) > max_points:
+                    tag.timestamps = tag.timestamps[-max_points:]
+                    tag.values = tag.values[-max_points:]
+
+    def stop_cleanup_thread(self) -> None:
+        self._stop_event.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- add simple helper classes in `memory_leak_fixes`
- wire memory helpers into `EnpresorOPCDataViewBeforeRestructureLegacy.py`
- start the app state cleanup thread and register shutdown handler

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a7e81da408327a19e1c23e392a1e4