### PR TITLE
Fix memory monitor call in section 6-1

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4025,7 +4025,7 @@ def _register_callbacks_impl(app):
     )
     def update_section_6_1(n_intervals, which, state_data, lang, app_state_data, app_mode, active_machine_data):
         """Update section 6-1 with trend graph for the 12 counters, supporting historical data."""
-        memory_monitor.log_memory_if_high()
+        mem_utils.log_memory_if_high()
         if which != "main":
             raise PreventUpdate
         global previous_counter_values, display_settings

--- a/tests/test_update_section_6_1.py
+++ b/tests/test_update_section_6_1.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+
+dash = pytest.importorskip("dash")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+import autoconnect
+
+
+def test_update_section_6_1_calls_memory_monitor(monkeypatch):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    called = []
+    monkeypatch.setattr(callbacks.mem_utils, "log_memory_if_high", lambda: called.append(True))
+
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = app.callback_map["section-6-1.children"]["callback"]
+
+    monkeypatch.setattr(callbacks.counter_manager, "add_data_point", lambda *a, **k: None, raising=False)
+
+    callbacks.previous_counter_values = [0] * 12
+    callbacks.display_settings = {i: True for i in range(1, 13)}
+    callbacks.app_state.counter_history = {i: {"times": [], "values": []} for i in range(1, 13)}
+
+    func.__wrapped__(0, "main", {}, "en", {"connected": True}, {"mode": "demo"}, {"machine_id": 1})
+
+    assert called


### PR DESCRIPTION
## Summary
- use the `mem_utils` alias when calling `log_memory_if_high`
- test that the memory monitor is invoked when updating section 6-1

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab1eb6adc832797cac93a63e3bc38